### PR TITLE
Compare measurements as integers not strings

### DIFF
--- a/Day 1/part1.py
+++ b/Day 1/part1.py
@@ -4,11 +4,11 @@ lastMeasurement = None
 increaseCount = 0
 decreaseCount = 0
 
-for measurement in input:
+for measurement in [int(line) for line in input.readlines()]:
     if lastMeasurement:
         if measurement > lastMeasurement:
             increaseCount += 1
-        elif measurement < lastMeasurement:
+        else:
             decreaseCount += 1
     lastMeasurement = measurement
 


### PR DESCRIPTION
Although the end result is similar the > operation on strings does not
produce the same results as > on ints. On strings and other sequences
it uses a lexicographical ordering 
(https://docs.python.org/3/tutorial/datastructures.html#comparing-sequences-and-other-types) 
which does not always match the numeric comparison.

For example:

```console
Python 3.9.6 (default, Jun 28 2021, 08:57:49)
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> '1000' < '997'
True
>>> 1000 < 997
False
```

You don't have this problem in part two because you convert the
strings to ints.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>